### PR TITLE
Add asRows Flow operator

### DIFF
--- a/copper-flow/src/androidTest/java/app/cash/copper/flow/AsRowsTest.kt
+++ b/copper-flow/src/androidTest/java/app/cash/copper/flow/AsRowsTest.kt
@@ -1,0 +1,66 @@
+package app.cash.copper.flow
+
+import androidx.test.runner.AndroidJUnit4
+import app.cash.copper.testing.Employee
+import app.cash.copper.testing.Employee.Companion.queryOf
+import app.cash.copper.testing.NullQuery
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.time.ExperimentalTime
+
+@ExperimentalCoroutinesApi
+@ExperimentalTime
+@RunWith(AndroidJUnit4::class)
+class AsRowsTest {
+  @Test fun asRowsEmpty() = runBlocking {
+    queryOf()
+      .asRows(mapper = Employee.MAPPER)
+      .test {
+        expectComplete()
+      }
+  }
+
+  @Test fun asRows() = runBlocking {
+    queryOf("alice", "Alice Allison", "bob", "Bob Bobberson")
+      .asRows(mapper = Employee.MAPPER)
+      .test {
+        assertThat(expectItem()).isEqualTo(Employee("alice", "Alice Allison"))
+        assertThat(expectItem()).isEqualTo(Employee("bob", "Bob Bobberson"))
+        expectComplete()
+      }
+  }
+
+  @Test fun asRowsStopsWhenCanceled() = runBlocking {
+    var count = 0
+    queryOf("alice", "Alice Allison", "bob", "Bob Bobberson", "eve", "Eve Evenson")
+      .asRows {
+        count++
+        Employee.MAPPER.invoke(it)
+      }
+      .take(1)
+      .test {
+        expectItem()
+        expectComplete()
+      }
+    // This is 2 not 1 because of how the implementation works. It will always be N+1.
+    assertThat(count).isEqualTo(2)
+  }
+
+  @Test fun asRowsEmptyWhenNullCursor() = runBlocking {
+    var count = 0
+    NullQuery
+      .asRows {
+        count++
+        Employee.MAPPER.invoke(it)
+      }
+      .test {
+        expectComplete()
+      }
+    assertThat(count).isEqualTo(0)
+  }
+}

--- a/copper-rx2/src/androidTest/java/app/cash/copper/rx2/QueryAsRowsTest.java
+++ b/copper-rx2/src/androidTest/java/app/cash/copper/rx2/QueryAsRowsTest.java
@@ -1,52 +1,41 @@
 package app.cash.copper.rx2;
 
-import android.database.Cursor;
-import android.database.MatrixCursor;
 import androidx.test.runner.AndroidJUnit4;
 import app.cash.copper.Query;
+import app.cash.copper.testing.Employee;
 import app.cash.copper.testing.NullQuery;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import kotlin.jvm.functions.Function1;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static app.cash.copper.testing.Employee.queryOf;
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(AndroidJUnit4.class)
 @SuppressWarnings("CheckResult")
 public final class QueryAsRowsTest {
-  private static final String FIRST_NAME = "first_name";
-  private static final String LAST_NAME = "last_name";
-  private static final String[] COLUMN_NAMES = { FIRST_NAME, LAST_NAME };
-
   @Test public void asRowsEmpty() {
-    MatrixCursor cursor = new MatrixCursor(COLUMN_NAMES);
-    Query query = new CursorQuery(cursor);
-    List<Name> names = RxContentResolver.asRows(query, Name.MAP).toList().blockingGet();
-    assertThat(names).isEmpty();
+    List<Employee> employees =
+      RxContentResolver.asRows(queryOf(), Employee.MAPPER).toList().blockingGet();
+    assertThat(employees).isEmpty();
   }
 
   @Test public void asRows() {
-    MatrixCursor cursor = new MatrixCursor(COLUMN_NAMES);
-    cursor.addRow(new Object[] { "Alice", "Allison" });
-    cursor.addRow(new Object[] { "Bob", "Bobberson" });
-
-    Query query = new CursorQuery(cursor);
-    List<Name> names = RxContentResolver.asRows(query, Name.MAP).toList().blockingGet();
-    assertThat(names).containsExactly(new Name("Alice", "Allison"), new Name("Bob", "Bobberson"));
+    Query query = queryOf("alice", "Alice Allison", "bob", "Bob Bobberson");
+    List<Employee> employees =
+      RxContentResolver.asRows(query, Employee.MAPPER).toList().blockingGet();
+    assertThat(employees).containsExactly(
+      new Employee("alice", "Alice Allison"),
+      new Employee("bob", "Bob Bobberson"));
   }
 
   @Test public void asRowsStopsWhenUnsubscribed() {
-    MatrixCursor cursor = new MatrixCursor(COLUMN_NAMES);
-    cursor.addRow(new Object[] { "Alice", "Allison" });
-    cursor.addRow(new Object[] { "Bob", "Bobberson" });
-
-    Query query = new CursorQuery(cursor);
+    Query query = queryOf("alice", "Alice Allison", "bob", "Bob Bobberson");
     final AtomicInteger count = new AtomicInteger();
     RxContentResolver.asRows(query, c -> {
       count.incrementAndGet();
-      return Name.MAP.invoke(c);
+      return Employee.MAPPER.invoke(c);
     }).take(1).blockingFirst();
     assertThat(count.get()).isEqualTo(1);
   }
@@ -55,50 +44,9 @@ public final class QueryAsRowsTest {
     final AtomicInteger count = new AtomicInteger();
     RxContentResolver.asRows(NullQuery.INSTANCE, cursor -> {
       count.incrementAndGet();
-      return Name.MAP.invoke(cursor);
+      return Employee.MAPPER.invoke(cursor);
     }).test().assertNoValues().assertComplete();
 
     assertThat(count.get()).isEqualTo(0);
-  }
-
-  static final class Name {
-    static final Function1<Cursor, Name> MAP = cursor -> new Name( //
-        cursor.getString(cursor.getColumnIndexOrThrow(FIRST_NAME)),
-        cursor.getString(cursor.getColumnIndexOrThrow(LAST_NAME)));
-
-    final String first;
-    final String last;
-
-    Name(String first, String last) {
-      this.first = first;
-      this.last = last;
-    }
-
-    @Override public boolean equals(Object o) {
-      if (o == this) return true;
-      if (!(o instanceof Name)) return false;
-      Name other = (Name) o;
-      return first.equals(other.first) && last.equals(other.last);
-    }
-
-    @Override public int hashCode() {
-      return first.hashCode() * 17 + last.hashCode();
-    }
-
-    @Override public String toString() {
-      return "Name[" + first + ' ' + last + ']';
-    }
-  }
-
-  static final class CursorQuery implements Query {
-    private final Cursor cursor;
-
-    CursorQuery(Cursor cursor) {
-      this.cursor = cursor;
-    }
-
-    @Override public Cursor run() {
-      return cursor;
-    }
   }
 }

--- a/copper-testing/src/main/java/app/cash/copper/testing/Employee.kt
+++ b/copper-testing/src/main/java/app/cash/copper/testing/Employee.kt
@@ -15,9 +15,39 @@
  */
 package app.cash.copper.testing
 
+import android.database.Cursor
+import android.database.MatrixCursor
+import app.cash.copper.Query
+
 data class Employee(
   @JvmField
   val username: String,
   @JvmField
   val name: String
-)
+) {
+  companion object {
+    private const val columnUsername = "username"
+    private const val columnName = "name"
+
+    @JvmStatic
+    fun queryOf(vararg values: String): Query {
+      return object : Query {
+        override fun run(): Cursor? {
+          val cursor = MatrixCursor(arrayOf(columnUsername, columnName))
+          for (i in values.indices step 2) {
+            cursor.addRow(arrayOf<Any>(values[i], values[i + 1]))
+          }
+          return cursor
+        }
+      }
+    }
+
+    @JvmField
+    val MAPPER: (Cursor) -> Employee = { cursor ->
+      Employee(
+        cursor.getString(cursor.getColumnIndexOrThrow(columnUsername)),
+        cursor.getString(cursor.getColumnIndexOrThrow(columnName))
+      )
+    }
+  }
+}


### PR DESCRIPTION
Migrate the asRows Observable operator tests to use Employee object like the rest of the test suite.