### PR TITLE
Migrate to Sonatype Central Portal

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       - run: ./gradlew publish
         if: github.ref == 'refs/heads/trunk'
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME_APP_CASH }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD_APP_CASH }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,8 @@ jobs:
       - name: Build and publish artifacts
         run: ./gradlew build publish
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME_APP_CASH }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD_APP_CASH }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SECRET_PASSPHRASE }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## [Unreleased]
 
+Changed:
 
-## [0.1.0] - 2020-08-17
+- In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
+
+
+## [1.0.0] - 2020-08-17
 
 Initial release forked from SQLBrite.
 
 
-[Unreleased]: https://github.com/cashapp/turbine/compare/1.0.0...HEAD
-[1.0.0]: https://github.com/cashapp/turbine/releases/tag/1.0.0
+[Unreleased]: https://github.com/cashapp/copper/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/cashapp/copper/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ implementation 'app.cash.copper:copper-rx2:1.0.0'
 ```
 
 <details>
-<summary>Snapshots of the development version are available in Sonatype's snapshots repository.</summary>
+<summary>Snapshots of the development version are available in the Central Portal Snapshots repository.</summary>
 <p>
 
 ```groovy
 repositories {
   maven {
-    url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    url 'https://central.sonatype.com/repository/maven-snapshots/'
   }
 }
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
 GROUP=app.cash.copper
 VERSION_NAME=1.1.0-SNAPSHOT
 
+SONATYPE_AUTOMATIC_RELEASE=true
+SONATYPE_HOST=CENTRAL_PORTAL
+RELEASE_SIGNING_ENABLED=true
+
 POM_DESCRIPTION=A content provider wrapper for reactive queries.
 
 POM_URL=http://github.com/cashapp/copper/


### PR DESCRIPTION
See (internally) http://go/central-portal-migration-app-cash for context.